### PR TITLE
in apiutil/responses.go, get `nextPageUrl` working

### DIFF
--- a/apiutil/responses.go
+++ b/apiutil/responses.go
@@ -3,6 +3,7 @@ package apiutil
 import (
 	"encoding/json"
 	"net/http"
+	"strconv"
 )
 
 func WriteResponse(w http.ResponseWriter, data interface{}) error {
@@ -28,8 +29,17 @@ func WritePageResponse(w http.ResponseWriter, data interface{}, r *http.Request,
 	return jsonResponse(w, env)
 }
 
-// TODO
 func nextPageUrl(r *http.Request, p Page) string {
+	q := r.URL.Query()
+	pageNum := 1
+	if val, ok := q["page"]; ok {
+		var err error
+		if pageNum, err = strconv.Atoi(val[0]); err != nil {
+			return r.URL.String()
+		}
+	}
+	q.Set("page", strconv.Itoa(pageNum+1))
+	r.URL.RawQuery = q.Encode()
 	return r.URL.String()
 }
 


### PR DESCRIPTION
I'm having trouble testing this (when I run `go test` or `go install`, I get this error: `github.com/ramfox/api/vendor/golang.org/x/crypto/blake2b.supportsAVX: relocation target runtime.support_avx not defined`)

But!

This fills out the nextPageUrl function, which returns the url with all the same queries, but with pagination advanced one page!